### PR TITLE
allow-modals on iframe allows embedded html to alert()

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -36,7 +36,7 @@
     <div id="sg-vp-wrap">
       <div id="sg-cover"></div>
       <div id="sg-gen-container">
-        <iframe id="sg-viewport" name="sg-viewport" sandbox="allow-same-origin allow-scripts allow-popups allow-forms"></iframe>
+        <iframe id="sg-viewport" name="sg-viewport" sandbox="allow-same-origin allow-scripts allow-popups allow-modals allow-forms"></iframe>
         <div id="sg-rightpull-container">
           <div id="sg-rightpull"></div>
         </div>


### PR DESCRIPTION
Ran into a case where demo html needed to alert(). This should allow for that.